### PR TITLE
fix: serialise the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main  # Change this to your default branch if different
 
+# The next version is derived from the tags that exist when the job starts, so
+# two runs at once compute the same version and all but one fail to create it.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The Release workflow runs on every push to `main` and derives the next version from the tags present when the job starts. When several pushes land close together the runs overlap, all compute the same version, and every one but the first fails with `a release with the same tag name already exists`.

This happened three times when the five open Dependabot pull requests were merged in quick succession (runs for `50755e4`, `f7cb656` and `24ce793` all tried to create `v1.1.18`), and previously on 2026-01-19 for the same reason.

A `concurrency` group serialises the runs, so each one sees the tag created by its predecessor and computes the next version correctly.